### PR TITLE
Fix test to detect if script is being sourced or not

### DIFF
--- a/venv.sh
+++ b/venv.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
-# Checking if the running process is "/bin/sh"
-# If it's "/bin/sh" then the user is executing the file directly
-# We want the user to source the file instead (source ./venv.sh or . ./venv.sh)
-if ps -p $$ --no-headers -o cmd | grep -q "^/bin/bash "; then
+# Checking if script is being sourced (only works for bash)
+(return 0 2>/dev/null) && SOURCED=1 || SOURCED=0
+if [ $SOURCED != 1 ]; then
     echo "Please source the command instead of executing it:"
     echo "  source $0"
     exit 1


### PR DESCRIPTION
Test was not working in case of several scripts embedded, like when we use it from a jenkinsfile e.g. 

(return 0 2>/dev/null) executes return in a subshell and suppresses the error message; afterwards the exit code indicates whether the script was sourced (0) or not (1), which is used with the && and || operators to set the sourced variable accordingly.

Cf. https://stackoverflow.com/a/28776166/4469222